### PR TITLE
Update README to set QGIS 3.34 as minimum version required

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ A QGIS Plugin for exporting layer styles to different formats.
 
 **Experimental**
 
-Tested with QGIS 3.24. 
+Tested with QGIS 3.34. 
 
-**Warning**: In recent versions of QGIS (e.g. 3.34) the style exports are no longer working with the [geostyler-qgis-parser](https://github.com/geostyler/geostyler-qgis-parser). This may requires to the QGIS parser - see <https://github.com/geostyler/geostyler-qgis-parser/issues/455>. 
+**Warning**: In previous versions of QGIS (e.g. 3.24) the XML used to store
+styles in QGIS projects is in a different format that is not compatible with
+newer versions of the [geostyler-qgis-parser](https://github.com/geostyler/geostyler-qgis-parser) (see this [issue](https://github.com/geostyler/geostyler-qgis-parser/issues/455)). 
 
 ## Installation
 
@@ -25,7 +27,7 @@ Next we create a symbolic link to make the cloned GitHub repository appear in th
 
 Windows Command Prompt:
 
-```
+```bat
 mklink /D "%APPDATA%\QGIS\QGIS3\profiles\default\python\plugins\geostyler" "C:\GitHub\geostyler-qgis-plugin"
 ```
 
@@ -42,7 +44,7 @@ New-Item -ItemType SymbolicLink -Path $LinkPath -Target $SourcePath
 
 Bash (untested):
 
-```
+```bash
 ln -s /path/to/source /home/username/.local/share/QGIS/QGIS3/profiles/default/python/plugins/geostyler
 ```
 
@@ -53,14 +55,17 @@ You should now be able to open Plugins > Manage and Install Plugins and find the
 The plugin relies on [geostyler-cli](https://github.com/geostyler/geostyler-cli) - GeoStyler's command-line tool.
 This needs to be available on the system path, or placed in the plugin folder.
 
-Binary releases are available on the [release pages](https://github.com/geostyler/geostyler-cli/releases), for example [4.0.0](https://github.com/geostyler/geostyler-cli/releases/tag/v4.0.0).
+Binary releases are available on the [release pages](https://github.com/geostyler/geostyler-cli/releases), for example [4.3.1](https://github.com/geostyler/geostyler-cli/releases/tag/v4.3.1).
+
+**Note** the minimum required version of GeoStyler to work with the plugin
+is **4.3.1**.
 
 Example script in PowerShell:
 
 ```ps
-$zipUrl = "https://github.com/geostyler/geostyler-cli/releases/download/v4.0.0/geostyler-cli-win.exe.zip"
+$zipUrl = "https://github.com/geostyler/geostyler-cli/releases/download/v4.3.1/geostyler-win.exe.zip"
 $destinationPath = "C:\GitHub\geostyler-qgis-plugin\geostyler"
-$zipFile = "$destinationPath\geostyler-cli-win.exe.zip"
+$zipFile = "$destinationPath\geostyler-win.exe.zip"
 
 Write-Host "Downloading ZIP file..."
 Invoke-WebRequest -Uri $zipUrl -OutFile $zipFile
@@ -74,8 +79,8 @@ Check that the program runs successfully on the command line:
 
 ```
 cd C:\GitHub\geostyler-qgis-plugin\geostyler
-./geostyler-cli --version
-# v4.0.0
+./geostyler --version
+# v4.3.1
 ```
 Now start QGIS and when right-clicking on vector or raster layers you should see the GeoStyler option in the context menu.
 

--- a/geostyler/client_wrapper.py
+++ b/geostyler/client_wrapper.py
@@ -18,10 +18,10 @@ def run_geostyler(input_file, output_file, output_format):
     update_environment_path()
 
     # Define the command and parameters
-    # command = ["geostyler-cli", "--version"]
+    # command = ["geostyler", "--version"]
 
     command = [
-        "geostyler-cli",
+        "geostyler",
         input_file,
         "--source",
         "qgis",

--- a/geostyler/metadata.txt
+++ b/geostyler/metadata.txt
@@ -4,16 +4,16 @@
 
 [general]
 name=GeoStyler
-qgisMinimumVersion=3.0
+qgisMinimumVersion=3.34
 description=GeoStyler exporter
-version=0.1
+version=0.2
 author=GeoStyler Team
 email=sethg@geographika.net
 
 about=Export styles using GeoStyler
 
-tracker=http://bugs
-repository=http://repo
+tracker=https://github.com/geostyler/geostyler-qgis-plugin/issues
+repository=https://github.com/geostyler/geostyler-qgis-plugin
 # End of mandatory metadata
 
 # Recommended items:
@@ -25,7 +25,7 @@ hasProcessingProvider=no
 # Tags are comma separated with spaces allowed
 tags=python
 
-homepage=http://homepage
+homepage=https://github.com/geostyler/geostyler-qgis-plugin
 category=Plugins
 icon=icon.png
 # experimental flag


### PR DESCRIPTION
Also update to new binary name `geostyler` rather than `geostyler-cli`. 
Tested and working on QGIS 3.34 LTR and new GeoStyler client 4.3.1.
